### PR TITLE
Remove brand name from user actions

### DIFF
--- a/modules/Home/language/en_us.lang.php
+++ b/modules/Home/language/en_us.lang.php
@@ -151,7 +151,7 @@ $mod_strings = array (
   'LBL_RETRIEVING_PAGE' => 'Retrieving Page...',
 
   // Default out-of-box names for tabs
-  'LBL_HOME_PAGE_1_NAME' => 'My SuiteCRM',
+  'LBL_HOME_PAGE_1_NAME' => 'My CRM',
   'LBL_HOME_PAGE_2_NAME' => 'Sales',
   'LBL_HOME_PAGE_3_NAME' => 'Support',
   'LBL_HOME_PAGE_6_NAME' => 'Marketing',//bug 16510, separate the support and marketing page from each other


### PR DESCRIPTION
Brand name should not be there as this is for the user (admin rights) and not for the administrator. 
This is for "My CRM panel" so brand name is not useful there and will cause some "learning noise"

Question: line 183 -  'LBL_SUGAR_COMMUNITY_EDITION' can be removed?
